### PR TITLE
Ability to copy a SafeSqlBuilder

### DIFF
--- a/safesql/src/main/java/org/dhatim/safesql/SafeSqlBuilder.java
+++ b/safesql/src/main/java/org/dhatim/safesql/SafeSqlBuilder.java
@@ -33,7 +33,12 @@ public class SafeSqlBuilder implements SafeSqlizable {
         this.parameters = new ArrayList<>();
     }
 
-    private SafeSqlBuilder(SafeSqlBuilder other) {
+    public SafeSqlBuilder(String query) {
+        this.sqlBuilder = new StringBuilder(query);
+        this.parameters = new ArrayList<>();
+    }
+
+    public SafeSqlBuilder(SafeSqlBuilder other) {
         this.sqlBuilder = new StringBuilder(other.sqlBuilder.toString());
         this.parameters = new ArrayList<>(other.parameters);
     }


### PR DESCRIPTION
Copying a `SafeSqlBuilder` is useful when you want to run a complex queries multiple times with different parameters (see `DatabaseAccessor.updateWithValues` in DSN for an example).